### PR TITLE
pass allow_ssl_requests_only flag to underlying module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ module "aws_config_label" {
 
 module "storage" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "0.20.0"
+  version = "0.23.0"
   count   = module.this.enabled ? 1 : 0
 
   acl                                    = "private"
@@ -31,6 +31,7 @@ module "storage" {
   ignore_public_acls                     = true
   restrict_public_buckets                = true
   access_log_bucket_name                 = var.access_log_bucket_name
+  allow_ssl_requests_only                = var.allow_ssl_requests_only
 
   tags       = module.this.tags
   attributes = ["aws-config"]

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,9 @@ variable "access_log_bucket_name" {
   default     = ""
   description = "Name of the S3 bucket where s3 access log will be sent to"
 }
+
+variable "allow_ssl_requests_only" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to require requests to use Secure Socket Layer (HTTPS/SSL). This will explicitly deny access to HTTP requests"
+}


### PR DESCRIPTION
## what

* Pass the `allow_ssl_requests_only` flag to the underlying storage module

## why

* AWS Foundation Best Practices