### PR TITLE
fix bug with policy generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ Available targets:
 
 | Name | Type |
 |------|------|
-| [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.aws_config_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Available targets:
 |------|------|
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.aws_config_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -26,6 +26,7 @@
 |------|------|
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.aws_config_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,7 +24,6 @@
 
 | Name | Type |
 |------|------|
-| [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.aws_config_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/main.tf
+++ b/main.tf
@@ -99,11 +99,11 @@ data "aws_iam_policy_document" "aws_config_bucket_policy" {
 # Locals and Data Sources
 #-----------------------------------------------------------------------------------------------------------------------
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 
 locals {
   current_account_id = data.aws_caller_identity.current.account_id
   config_spn         = "config.amazonaws.com"
-  s3_bucket_id       = module.this.enabled ? module.storage[0].bucket_id : ""
-  s3_bucket_arn      = module.this.enabled ? module.storage[0].bucket_arn : ""
+  s3_bucket_arn      = format("arn:%s:s3:::%s", data.aws_partition.current.name, module.this.id)
   s3_object_prefix   = format("%s/AWSLogs/*", local.s3_bucket_arn)
 }

--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,6 @@ data "aws_partition" "current" {}
 locals {
   current_account_id = data.aws_caller_identity.current.account_id
   config_spn         = "config.amazonaws.com"
-  s3_bucket_arn      = format("arn:%s:s3:::%s", data.aws_partition.current.id, module.aws_config_label.attributes["name"])
+  s3_bucket_arn      = format("arn:%s:s3:::%s", data.aws_partition.current.id, module.aws_config_label.id)
   s3_object_prefix   = format("%s/AWSLogs/*", local.s3_bucket_arn)
 }

--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,6 @@ data "aws_partition" "current" {}
 locals {
   current_account_id = data.aws_caller_identity.current.account_id
   config_spn         = "config.amazonaws.com"
-  s3_bucket_arn      = format("arn:%s:s3:::%s", data.aws_partition.current.id, module.this.id)
+  s3_bucket_arn      = format("arn:%s:s3:::%s", data.aws_partition.current.id, module.aws_config_label.attributes["name"])
   s3_object_prefix   = format("%s/AWSLogs/*", local.s3_bucket_arn)
 }

--- a/main.tf
+++ b/main.tf
@@ -32,17 +32,11 @@ module "storage" {
   restrict_public_buckets                = true
   access_log_bucket_name                 = var.access_log_bucket_name
   allow_ssl_requests_only                = var.allow_ssl_requests_only
+  policy                                 = join("", data.aws_iam_policy_document.aws_config_bucket_policy.*.json)
 
   tags       = module.this.tags
   attributes = ["aws-config"]
   context    = module.this.context
-}
-
-resource "aws_s3_bucket_policy" "bucket_policy" {
-  bucket = local.s3_bucket_id
-  policy = data.aws_iam_policy_document.aws_config_bucket_policy[0].json
-
-  depends_on = [module.storage]
 }
 
 data "aws_iam_policy_document" "aws_config_bucket_policy" {

--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,6 @@ data "aws_partition" "current" {}
 locals {
   current_account_id = data.aws_caller_identity.current.account_id
   config_spn         = "config.amazonaws.com"
-  s3_bucket_arn      = format("arn:%s:s3:::%s", data.aws_partition.current.name, module.this.id)
+  s3_bucket_arn      = format("arn:%s:s3:::%s", data.aws_partition.current.id, module.this.id)
   s3_object_prefix   = format("%s/AWSLogs/*", local.s3_bucket_arn)
 }


### PR DESCRIPTION
## what

* Fix a bug with the bucket IAM policy when `allow_ssl_requests_only` is set to `true`

## notes

I had to update the module to calculate the bucket ARN now instead of reading it as an output from `module.storage[0].bucket_arn` because the latter would cause a cyclic dependency. 
