### PR TITLE
Add common sqs based log collection handles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,10 @@ module "storage" {
   allow_ssl_requests_only                = var.allow_ssl_requests_only
   policy                                 = join("", data.aws_iam_policy_document.aws_config_bucket_policy.*.json)
 
+  bucket_notifications_enabled       = var.bucket_notifications_enabled
+  bucket_notifications_type          = var.bucket_notifications_type
+  bucket_notifications_prefix        = var.bucket_notifications_prefix
+
   tags       = module.this.tags
   attributes = ["aws-config"]
   context    = module.this.context

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,8 @@ output "enabled" {
   value       = module.this.enabled
   description = "Is module enabled"
 }
+
+output "bucket_notifications_sqs_queue_arn" {
+  value       = module.storage.bucket_notifications_sqs_queue_arn
+  description = "Notifications SQS queue ARN"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -93,3 +93,21 @@ variable "allow_ssl_requests_only" {
   default     = false
   description = "Set to `true` to require requests to use Secure Socket Layer (HTTPS/SSL). This will explicitly deny access to HTTP requests"
 }
+
+variable "bucket_notifications_enabled" {
+  type        = bool
+  description = "Send notifications for the object created events. Used for 3rd-party log collection from a bucket"
+  default     = false
+}
+
+variable "bucket_notifications_type" {
+  type        = string
+  description = "Type of the notification configuration. Only SQS is supported."
+  default     = "SQS"
+}
+
+variable "bucket_notifications_prefix" {
+  type        = string
+  description = "Prefix filter. Used to manage object notifications"
+  default     = ""
+}


### PR DESCRIPTION
## what
* Add common sqs based log collection handles

## why
* To follow other log storage bucket standartization initiative

## references
Example PR https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket/pull/37

