### PR TITLE
Support AWS Provider V5

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 5.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Available targets:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_aws_config_label"></a> [aws\_config\_label](#module\_aws\_config\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_storage"></a> [storage](#module\_storage) | cloudposse/s3-log-storage/aws | 0.26.0 |
+| <a name="module_storage"></a> [storage](#module\_storage) | cloudposse/s3-log-storage/aws | 1.4.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,7 +17,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_aws_config_label"></a> [aws\_config\_label](#module\_aws\_config\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_storage"></a> [storage](#module\_storage) | cloudposse/s3-log-storage/aws | 0.26.0 |
+| <a name="module_storage"></a> [storage](#module\_storage) | cloudposse/s3-log-storage/aws | 1.4.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 5.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 5.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 5.0"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ module "storage" {
   restrict_public_buckets                = true
   access_log_bucket_name                 = var.access_log_bucket_name
   allow_ssl_requests_only                = var.allow_ssl_requests_only
-  policy                                 = join("", data.aws_iam_policy_document.aws_config_bucket_policy.*.json)
+  policy                                 = join("", data.aws_iam_policy_document.aws_config_bucket_policy[*].json)
 
   bucket_notifications_enabled = var.bucket_notifications_enabled
   bucket_notifications_type    = var.bucket_notifications_type

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ module "aws_config_label" {
 
 module "storage" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "0.26.0"
+  version = "1.4.0"
   count   = module.this.enabled ? 1 : 0
 
   acl                                    = "private"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,15 +1,15 @@
 output "bucket_domain_name" {
-  value       = join("", module.storage.*.bucket_domain_name)
+  value       = join("", module.storage[*].bucket_domain_name)
   description = "FQDN of bucket"
 }
 
 output "bucket_id" {
-  value       = join("", module.storage.*.bucket_id)
+  value       = join("", module.storage[*].bucket_id)
   description = "Bucket Name (aka ID)"
 }
 
 output "bucket_arn" {
-  value       = join("", module.storage.*.bucket_arn)
+  value       = join("", module.storage[*].bucket_arn)
   description = "Bucket ARN"
 }
 
@@ -24,6 +24,6 @@ output "enabled" {
 }
 
 output "bucket_notifications_sqs_queue_arn" {
-  value       = join("", module.storage.*.bucket_notifications_sqs_queue_arn)
+  value       = join("", module.storage[*].bucket_notifications_sqs_queue_arn)
   description = "Notifications SQS queue ARN"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 5.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 5.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what

Support AWS Provider V5
Major release bc of S3 major release dependency update
Linter fixes

## why

Maintenance

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0
