### PR TITLE
Change `policy` to `source_policy_documents`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,6 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
-
 
 Here's how to invoke this example module in your projects
 

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ module "storage" {
   restrict_public_buckets                = true
   access_log_bucket_name                 = var.access_log_bucket_name
   allow_ssl_requests_only                = var.allow_ssl_requests_only
-  policy                                 = join("", data.aws_iam_policy_document.aws_config_bucket_policy[*].json)
+  source_policy_documents                = [join("", data.aws_iam_policy_document.aws_config_bucket_policy[*].json)]
 
   bucket_notifications_enabled = var.bucket_notifications_enabled
   bucket_notifications_type    = var.bucket_notifications_type


### PR DESCRIPTION
## what

* Use `source_policy_documents` instead of `policy`

## why

* `policy` is combined with `source_policy_documents` upstream, but there is a ref to `var.source_policy_documents` and not the combined `local.source_policy_documents` so using only `policy` is not working
* `policy` is also deprecated so usage needs to be removed

## references

- #31 
- #14 